### PR TITLE
chore: Update references after repo rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This documents explains the processes and practices recommended for contributing
 this operator.
 
 - Generally, before developing enhancements to this charm, you should consider [opening an issue
-  ](https://github.com/canonical/pyroscope-k8s-operator/issues) explaining your use case.
+  ](https://github.com/canonical/pyroscope-operators/issues) explaining your use case.
 - If you would like to chat with us about your use-cases or proposed implementation, you can reach
   us at the [Canonical Observability Matrix public channel](https://matrix.to/#/#cos:ubuntu.com)
   or [Discourse](https://discourse.charmhub.io/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pyroscope-k8s-operator
+# pyroscope-operators
 This charmed operator is part of automating the operational procedures of running Grafana Pyroscope, an open-source profiling backend, in microservices mode.
 
 This repository hosts two charms following the [coordinated-workers](https://discourse.charmhub.io/t/cos-lite-docs-managing-deployments-of-cos-lite-ha-addons/15213) pattern.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-The easiest way to report a security issue is through a [Github Private Security Report](https://github.com/canonical/pyroscope-k8s-operator/security/advisories/new)
+The easiest way to report a security issue is through a [Github Private Security Report](https://github.com/canonical/pyroscope-operators/security/advisories/new)
 with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
 
 Alternatively, to report a security issue via email, please email [security@ubuntu.com](mailto:security@ubuntu.com) with a description of the issue,

--- a/coordinator/README.md
+++ b/coordinator/README.md
@@ -1,7 +1,7 @@
 # Pyroscope Operator
 
 [![CharmHub Badge](https://charmhub.io/pyroscope-coordinator-k8s/badge.svg)](https://charmhub.io/pyroscope-coordinator-k8s)
-[![Release](https://github.com/canonical/pyroscope-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/pyroscope-k8s-operator/actions/workflows/release.yaml)
+[![Release](https://github.com/canonical/pyroscope-operators/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/pyroscope-operators/actions/workflows/release.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
 
 This repository contains the source code for a Charmed Operator that drives [Pyroscope] on Kubernetes. It is destined to work together with [pyroscope-worker-k8s](https://charmhub.io/pyroscope-worker-k8s) to deploy and operate Grafana Pyroscope, a distributed profiling backend backed by Grafana. See [charmed Pyroscope HA](https://discourse.charmhub.io/t/18120) documentation for more details.
@@ -24,4 +24,4 @@ on enhancements to this charm following best practice guidelines, and the
 [contributing] doc for developer guidance.
 
 [Pyroscope]: https://grafana.com/oss/pyroscope/
-[contributing]: https://github.com/canonical/pyroscope-k8s-operator/blob/main/CONTRIBUTING.md
+[contributing]: https://github.com/canonical/pyroscope-operators/blob/main/CONTRIBUTING.md

--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -32,8 +32,8 @@ resources:
 links:
   documentation: https://discourse.charmhub.io/t/18121
   website: https://charmhub.io/pyroscope-coordinator-k8s
-  source: https://github.com/canonical/pyroscope-k8s-operator/tree/main/coordinator
-  issues: https://github.com/canonical/pyroscope-k8s-operator/issues
+  source: https://github.com/canonical/pyroscope-operators/tree/main/coordinator
+  issues: https://github.com/canonical/pyroscope-operators/issues
 
 provides:
   pyroscope-cluster:

--- a/coordinator/src/pyroscope_config.py
+++ b/coordinator/src/pyroscope_config.py
@@ -20,8 +20,6 @@ class PyroscopeRole(StrEnum):
       -> https://grafana.com/docs/pyroscope/latest/configure-server/
     """
 
-    # FIXME: add other optional modules
-    # https://github.com/canonical/pyroscope-k8s-operator/issues/4
     all = "all"  # default, meta-role.
     querier = "querier"
     query_frontend = "query-frontend"

--- a/coordinator/terraform/README.md
+++ b/coordinator/terraform/README.md
@@ -33,7 +33,7 @@ Upon application, the module exports the following outputs:
 ## Usage
 
 > [!NOTE]
-> This module is intended to be used only in conjunction with its counterpart, [pyroscope worker module](https://github.com/canonical/pyroscope-k8s-operator/worker) and, when deployed in isolation, is not functional. 
+> This module is intended to be used only in conjunction with its counterpart, [pyroscope worker module](https://github.com/canonical/pyroscope-operators/worker) and, when deployed in isolation, is not functional. 
 > For the pyroscope HA solution module deployment, check [pyroscope HA module](https://github.com/canonical/observability)
 
 ### Basic usage
@@ -42,7 +42,7 @@ In order to deploy this standalone module, create a `main.tf` file with the foll
 ```hcl
 module "pyroscope-coordinator" {
 
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//coordinator/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//coordinator/terraform"
   app_name    = var.app_name
   channel     = var.channel
   config      = var.config

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,8 +3,8 @@
 This is a Terraform module facilitating the deployment of pyroscope solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
 The solution consists of the following Terraform modules:
-- [pyroscope-coordinator-k8s](https://github.com/canonical/pyroscope-k8s-operator/tree/main/coordinator): ingress, cluster coordination, single integration facade.
-- [pyroscope-worker-k8s](https://github.com/canonical/pyroscope-k8s-operator/tree/main/worker): run one or more pyroscope application components.
+- [pyroscope-coordinator-k8s](https://github.com/canonical/pyroscope-operators/tree/main/coordinator): ingress, cluster coordination, single integration facade.
+- [pyroscope-worker-k8s](https://github.com/canonical/pyroscope-operators/tree/main/worker): run one or more pyroscope application components.
 - [s3-integrator](https://github.com/canonical/s3-integrator): facade for S3 storage configurations.
 
 This Terraform module deploys pyroscope in its [microservices mode](https://grafana.com/docs/pyroscope/latest/reference-pyroscope-architecture/deployment-modes/#microservices-mode), which runs each one of the required roles in distinct processes. [See](https://discourse.charmhub.io/t/topic/15213) to understand more about pyroscope roles.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,7 +36,7 @@ resource "juju_application" "s3_integrator" {
 }
 
 module "pyroscope_coordinator" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//coordinator/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//coordinator/terraform"
   model       = var.model
   channel     = var.channel
   revision    = var.coordinator_revision
@@ -45,7 +45,7 @@ module "pyroscope_coordinator" {
 }
 
 module "pyroscope_querier" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   app_name    = var.querier_name
   model       = var.model
   channel     = var.channel
@@ -62,7 +62,7 @@ module "pyroscope_querier" {
 }
 
 module "pyroscope_query_frontend" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   app_name    = var.query_frontend_name
   model       = var.model
   channel     = var.channel
@@ -79,7 +79,7 @@ module "pyroscope_query_frontend" {
 }
 
 module "pyroscope_ingester" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   app_name    = var.ingester_name
   model       = var.model
   channel     = var.channel
@@ -96,7 +96,7 @@ module "pyroscope_ingester" {
 }
 
 module "pyroscope_distributor" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   app_name    = var.distributor_name
   model       = var.model
   channel     = var.channel
@@ -113,7 +113,7 @@ module "pyroscope_distributor" {
 }
 
 module "pyroscope_compactor" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   app_name    = var.compactor_name
   model       = var.model
   channel     = var.channel
@@ -130,7 +130,7 @@ module "pyroscope_compactor" {
 }
 
 module "pyroscope_query_scheduler" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   app_name    = var.query_scheduler_name
   model       = var.model
   channel     = var.channel
@@ -148,7 +148,7 @@ module "pyroscope_query_scheduler" {
 
 
 module "pyroscope_store_gateway" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   app_name    = var.store_gateway_name
   model       = var.model
   channel     = var.channel
@@ -165,7 +165,7 @@ module "pyroscope_store_gateway" {
 }
 
 module "pyroscope_tenant_settings" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   app_name    = var.tenant_settings_name
   model       = var.model
   channel     = var.channel
@@ -182,7 +182,7 @@ module "pyroscope_tenant_settings" {
 }
 
 module "pyroscope_ad_hoc_profiles" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   app_name    = var.ad_hoc_profiles_name
   model       = var.model
   channel     = var.channel

--- a/tests/integration/test_core_cos_integrations.py
+++ b/tests/integration/test_core_cos_integrations.py
@@ -258,7 +258,7 @@ def test_alert_rules_integration(juju: Juju):
 
 @pytest.mark.teardown
 @pytest.mark.xfail(
-    reason="https://github.com/canonical/pyroscope-k8s-operator/issues/208"
+    reason="https://github.com/canonical/pyroscope-operators/issues/208"
 )
 def test_teardown(juju: Juju):
     # GIVEN a pyroscope cluster with core cos relations

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,7 +1,7 @@
 # Pyroscope Operator
 
 [![CharmHub Badge](https://charmhub.io/pyroscope-worker-k8s/badge.svg)](https://charmhub.io/pyroscope-worker-k8s)
-[![Release](https://github.com/canonical/pyroscope-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/pyroscope-k8s-operator/actions/workflows/release.yaml)
+[![Release](https://github.com/canonical/pyroscope-operators/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/pyroscope-operators/actions/workflows/release.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
 
 This repository contains the source code for a Charmed Operator that drives [Pyroscope] on Kubernetes. It is destined to work together with [pyroscope-coordinator-k8s](https://charmhub.io/pyroscope-coordinator-k8s) to deploy and operate Grafana Pyroscope, a distributed profiling backend backed by Grafana. See [charmed Pyroscope HA](https://discourse.charmhub.io/t/18120) documentation for more details.
@@ -24,4 +24,4 @@ on enhancements to this charm following best practice guidelines, and the
 [contributing] doc for developer guidance.
 
 [Pyroscope]: https://grafana.com/oss/pyroscope/
-[contributing]: https://github.com/canonical/pyroscope-k8s-operator/blob/main/CONTRIBUTING.md
+[contributing]: https://github.com/canonical/pyroscope-operators/blob/main/CONTRIBUTING.md

--- a/worker/charmcraft.yaml
+++ b/worker/charmcraft.yaml
@@ -30,8 +30,8 @@ resources:
 links:
   documentation: https://discourse.charmhub.io/t/18122
   website: https://charmhub.io/pyroscope-worker-k8s
-  source: https://github.com/canonical/pyroscope-k8s-operator/tree/main/worker
-  issues: https://github.com/canonical/pyroscope-k8s-operator/issues
+  source: https://github.com/canonical/pyroscope-operators/tree/main/worker
+  issues: https://github.com/canonical/pyroscope-operators/issues
 
 requires:
   pyroscope-cluster:

--- a/worker/terraform/README.md
+++ b/worker/terraform/README.md
@@ -33,14 +33,14 @@ Upon application, the module exports the following outputs:
 ## Usage
 
 > [!NOTE]
-> This module is intended to be used only in conjunction with its counterpart, [pyroscope coordinator module](https://github.com/canonical/pyroscope-k8s-operator/coordinator) and, when deployed in isolation, is not functional. 
+> This module is intended to be used only in conjunction with its counterpart, [pyroscope coordinator module](https://github.com/canonical/pyroscope-operators/coordinator) and, when deployed in isolation, is not functional. 
 > For the pyroscope HA solution module deployment, check [pyroscope HA module](https://github.com/canonical/observability)
 
 ### Basic usage
 In order to deploy this standalone module, create a `main.tf` file with the following content:
 ```hcl
 module "pyroscope-worker" {
-  source      = "git::https://github.com/canonical/pyroscope-k8s-operator//worker/terraform"
+  source      = "git::https://github.com/canonical/pyroscope-operators//worker/terraform"
   model_name  = var.model_name
   app_name    = var.app_name
   channel     = var.channel


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
After repo rename, there were lots of references to the old repository name in code and docs.

## Solution
<!-- A summary of the solution addressing the above issue -->
Update references to point at `pyroscope-operators`. Closes #166.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed pyroscope, ... -->
