### PR TITLE
feat: Logs-based alert rules

### DIFF
--- a/coordinator/src/loki_alert_rules/error_level_logs_found.rule
+++ b/coordinator/src/loki_alert_rules/error_level_logs_found.rule
@@ -1,0 +1,7 @@
+alert: HighPercentageError
+expr: 100 * sum by (job) (rate({%%juju_topology%%} |= "level=error"[5m])) / sum by (job) (rate({%%juju_topology%%}[5m])) > 5
+for: 10m
+labels:
+  severity: critical
+annotations:
+  summary: "The {{ $labels.job }} is experiencing {{ printf \"%.2f\" $value }}% error-level logs rate."

--- a/coordinator/src/loki_alert_rules/log_volume.rule
+++ b/coordinator/src/loki_alert_rules/log_volume.rule
@@ -1,0 +1,10 @@
+groups:
+  - name: high-log-volume
+    rules:
+      - alert: HighLogVolume
+        expr: |
+          count_over_time(({%%juju_topology%%})[30s]) > 100
+        labels:
+            severity: high
+        annotations:
+            summary: Log rate is too high!

--- a/tests/integration/test_core_cos_integrations.py
+++ b/tests/integration/test_core_cos_integrations.py
@@ -256,6 +256,20 @@ def test_alert_rules_integration(juju: Juju):
         assert False, f"Request to Prometheus failed: {e}"
 
 
+def test_loki_alert_rules_integration(juju: Juju):
+        # GIVEN a pyroscope cluster integrated with loki
+    address = get_unit_ip_address(juju, LOKI_APP, 0)
+    # WHEN we query for alert rules
+    url = f"http://{address}:3100/loki/api/v1/rules"
+    # THEN we should get a successful response
+    try:
+        response = requests.get(url)
+        # TODO known issue: https://github.com/canonical/cos-coordinated-workers/issues/21
+        assert PYROSCOPE_APP in response.text
+    except requests.exceptions.RequestException as e:
+        assert False, f"Request to Loki failed: {e}"
+
+
 @pytest.mark.teardown
 @pytest.mark.xfail(
     reason="https://github.com/canonical/pyroscope-operators/issues/208"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Alert rules for the logs were missing from the charm.


## Solution
<!-- A summary of the solution addressing the above issue -->
Add a set of basic log-based alert rules. Closes #202.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Topology of the alert rules is still pointing at the coordinator: see https://github.com/canonical/cos-coordinated-workers/issues/21 for the reference.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Run integration tests for the COS integrations.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed pyroscope, ... -->
