### PR TITLE
feat: grafana source integration

### DIFF
--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -46,6 +46,11 @@ provides:
     interface: grafana_dashboard
     description: |
       Provide a grafana dashboard definition for monitoring Pyroscope.
+  grafana-source:
+    optional: true
+    interface: grafana_datasource
+    description: |
+      Provide a grafana datasource for querying Pyroscope data from Grafana.
   metrics-endpoint:
     optional: true
     interface: prometheus_scrape

--- a/coordinator/tests/unit/conftest.py
+++ b/coordinator/tests/unit/conftest.py
@@ -88,6 +88,11 @@ def catalogue():
 
 
 @pytest.fixture(scope="function")
+def grafana_source():
+    return Relation("grafana-source")
+
+
+@pytest.fixture(scope="function")
 def all_worker():
     return Relation(
         "pyroscope-cluster",

--- a/coordinator/tests/unit/test_grafana_source.py
+++ b/coordinator/tests/unit/test_grafana_source.py
@@ -1,0 +1,92 @@
+from unittest.mock import patch
+
+import ops
+
+import nginx_config
+from ops.testing import State
+
+
+def assert_unit_source_url_equals(
+    grafana_source_out: ops.testing.Relation, expected_value: str
+):
+    assert grafana_source_out.local_unit_data["grafana_source_host"] == expected_value
+
+
+def test_grafana_source_no_ingress(
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+    grafana_source,
+    peers,
+):
+    with patch("socket.getfqdn", new=lambda: "foo.com"):
+        state_out = context.run(
+            context.on.update_status(),
+            State(
+                relations=[peers, s3, all_worker, grafana_source],
+                containers=[nginx_container, nginx_prometheus_exporter_container],
+                unit_status=ops.ActiveStatus(),
+                leader=True,
+            ),
+        )
+    assert_unit_source_url_equals(
+        state_out.get_relation(grafana_source.id), "http://foo.com:8080"
+    )
+
+
+def test_grafana_source_with_k8s_fqdn(
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+    grafana_source,
+    external_host,
+    peers,
+):
+    with patch(
+        "socket.getfqdn",
+        new=lambda: "something-something.something-else.svc.cluster.local",
+    ):
+        state_out = context.run(
+            context.on.update_status(),
+            State(
+                relations=[peers, s3, all_worker, grafana_source],
+                containers=[nginx_container, nginx_prometheus_exporter_container],
+                unit_status=ops.ActiveStatus(),
+                leader=True,
+            ),
+        )
+    assert_unit_source_url_equals(
+        state_out.get_relation(grafana_source.id),
+        f"http://pyroscope-coordinator-k8s.{state_out.model.name}.svc.cluster.local:{nginx_config.http_server_port}",
+    )
+
+
+def test_grafana_source_ingress(
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+    grafana_source,
+    ingress,
+    external_host,
+    peers,
+):
+    with patch("socket.getfqdn", new=lambda: "foo.com"):
+        state_out = context.run(
+            context.on.update_status(),
+            State(
+                relations=[peers, s3, ingress, all_worker, grafana_source],
+                containers=[nginx_container, nginx_prometheus_exporter_container],
+                unit_status=ops.ActiveStatus(),
+                leader=True,
+            ),
+        )
+    assert_unit_source_url_equals(
+        state_out.get_relation(grafana_source.id),
+        f"http://{external_host}/{state_out.model.name}-pyroscope-coordinator-k8s",
+    )


### PR DESCRIPTION
Adds grafana datasource integration.

The pyroscope datasource is only supported in grafana 10+, so the question is if we should be merging this now, or wait for the grafana charm to catch up with the upstream versions.

Also, we currently don't have a way to surface the error, as grafana will happily accept the datasource but it won't allow querying it:

<img width="1136" height="328" alt="image" src="https://github.com/user-attachments/assets/0872ae93-2162-4790-80ac-a7930a57b563" />

<img width="335" height="253" alt="image" src="https://github.com/user-attachments/assets/a8317d0c-a49f-4e4b-9e78-5f4af947db9f" />

The only indication we have that something is wrong is an error log on grafana:

`2025-07-31T09:13:52.189Z [grafana] logger=context userId=1 orgId=1 uname=admin t=2025-07-31T09:13:52.189447827Z level=error msg="Could not find plugin definition for data source" datasource_type=pyroscope`