### PR TITLE
fix: profiling interface endpoint name

### DIFF
--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -24,7 +24,7 @@ logger = logging.getLogger()
 class ProfilingAppDatabagModel(pydantic.BaseModel):
     """Application databag model for the profiling interface."""
     otlp_grpc_endpoint_url: str
-    otlp_http_endpoint_url: Optional[str]=None
+    pyroscope_http_endpoint_url: Optional[str]=None
 
 
 class ProfilingEndpointProvider:
@@ -35,7 +35,7 @@ class ProfilingEndpointProvider:
 
     def publish_endpoint(self,
                          otlp_grpc_endpoint:str,
-                         otlp_http_endpoint:Optional[str]=None
+                         pyroscope_http_endpoint:Optional[str]=None
                          ):
         """Publish profiling ingestion endpoints to all relations."""
         for relation in self._relations:
@@ -43,7 +43,7 @@ class ProfilingEndpointProvider:
                 relation.save(
                     ProfilingAppDatabagModel(
                         otlp_grpc_endpoint_url=otlp_grpc_endpoint,
-                        otlp_http_endpoint_url=otlp_http_endpoint,
+                        pyroscope_http_endpoint_url=pyroscope_http_endpoint,
                     ),
                     self._app
                 )
@@ -55,7 +55,7 @@ class ProfilingEndpointProvider:
 @dataclasses.dataclass
 class _Endpoint:
     otlp_grpc: str
-    otlp_http: Optional[str]
+    pyroscope_http: Optional[str]
 
 
 class ProfilingEndpointRequirer:
@@ -70,7 +70,7 @@ class ProfilingEndpointRequirer:
             try:
                 data = relation.load(ProfilingAppDatabagModel, relation.app)
                 otlp_grpc_endpoint_url = data.otlp_grpc_endpoint_url
-                otlp_http_endpoint_url = data.otlp_http_endpoint_url
+                pyroscope_http_endpoint_url = data.pyroscope_http_endpoint_url
             except ops.ModelError:
                 logger.debug("failed to validate app data; is the relation still being created?")
                 continue
@@ -78,7 +78,7 @@ class ProfilingEndpointRequirer:
                 logger.debug("failed to validate app data; is the relation still settling?")
                 continue
             out.append(_Endpoint(
-                otlp_http=otlp_http_endpoint_url,
+                pyroscope_http=pyroscope_http_endpoint_url,
                 otlp_grpc=otlp_grpc_endpoint_url,
             ))
         return out

--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -24,7 +24,6 @@ logger = logging.getLogger()
 class ProfilingAppDatabagModel(pydantic.BaseModel):
     """Application databag model for the profiling interface."""
     otlp_grpc_endpoint_url: str
-    pyroscope_http_endpoint_url: Optional[str]=None
 
 
 class ProfilingEndpointProvider:
@@ -35,7 +34,6 @@ class ProfilingEndpointProvider:
 
     def publish_endpoint(self,
                          otlp_grpc_endpoint:str,
-                         pyroscope_http_endpoint:Optional[str]=None
                          ):
         """Publish profiling ingestion endpoints to all relations."""
         for relation in self._relations:
@@ -43,7 +41,6 @@ class ProfilingEndpointProvider:
                 relation.save(
                     ProfilingAppDatabagModel(
                         otlp_grpc_endpoint_url=otlp_grpc_endpoint,
-                        pyroscope_http_endpoint_url=pyroscope_http_endpoint,
                     ),
                     self._app
                 )
@@ -55,7 +52,6 @@ class ProfilingEndpointProvider:
 @dataclasses.dataclass
 class _Endpoint:
     otlp_grpc: str
-    pyroscope_http: Optional[str]
 
 
 class ProfilingEndpointRequirer:
@@ -70,7 +66,6 @@ class ProfilingEndpointRequirer:
             try:
                 data = relation.load(ProfilingAppDatabagModel, relation.app)
                 otlp_grpc_endpoint_url = data.otlp_grpc_endpoint_url
-                pyroscope_http_endpoint_url = data.pyroscope_http_endpoint_url
             except ops.ModelError:
                 logger.debug("failed to validate app data; is the relation still being created?")
                 continue
@@ -78,7 +73,6 @@ class ProfilingEndpointRequirer:
                 logger.debug("failed to validate app data; is the relation still settling?")
                 continue
             out.append(_Endpoint(
-                pyroscope_http=pyroscope_http_endpoint_url,
                 otlp_grpc=otlp_grpc_endpoint_url,
             ))
         return out

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -229,6 +229,7 @@ class PyroscopeCoordinatorCharm(CharmBase):
         self._reconcile_ingress()
         self.profiling_provider.publish_endpoint(
             otlp_grpc_endpoint=self._most_external_grpc_url,
+            pyroscope_http_endpoint=self._most_external_http_url
         )
 
     def _reconcile_ingress(self):

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -229,7 +229,6 @@ class PyroscopeCoordinatorCharm(CharmBase):
         self._reconcile_ingress()
         self.profiling_provider.publish_endpoint(
             otlp_grpc_endpoint=self._most_external_grpc_url,
-            pyroscope_http_endpoint=self._most_external_http_url,
         )
 
     def _reconcile_ingress(self):

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -229,7 +229,7 @@ class PyroscopeCoordinatorCharm(CharmBase):
         self._reconcile_ingress()
         self.profiling_provider.publish_endpoint(
             otlp_grpc_endpoint=self._most_external_grpc_url,
-            pyroscope_http_endpoint=self._most_external_http_url
+            pyroscope_http_endpoint=self._most_external_http_url,
         )
 
     def _reconcile_ingress(self):

--- a/coordinator/tests/unit/conftest.py
+++ b/coordinator/tests/unit/conftest.py
@@ -24,6 +24,12 @@ def k8s_patch(status=ActiveStatus(), is_ready=True):
             yield patcher
 
 
+@pytest.fixture(autouse=True)
+def patch_consolidate_alert_rules():
+    with patch("coordinated_workers.coordinator.Coordinator._consolidate_alert_rules"):
+        yield
+
+
 @pytest.fixture()
 def coordinator():
     return MagicMock()

--- a/coordinator/tests/unit/test_profiling_interface.py
+++ b/coordinator/tests/unit/test_profiling_interface.py
@@ -39,6 +39,7 @@ def test_provide_profiling(
         f"foo.com:{nginx_config.grpc_server_port}"
     )
 
+
 def test_provide_profiling_ingress(
     context,
     s3,

--- a/coordinator/tests/unit/test_profiling_interface.py
+++ b/coordinator/tests/unit/test_profiling_interface.py
@@ -38,8 +38,10 @@ def test_provide_profiling(
     assert profiling_out.local_app_data["otlp_grpc_endpoint_url"] == json.dumps(
         f"foo.com:{nginx_config.grpc_server_port}"
     )
-    assert profiling_out.local_app_data.get("otlp_http_endpoint_url") == json.dumps(
-        None
+    assert profiling_out.local_app_data.get(
+        "pyroscope_http_endpoint_url"
+    ) == json.dumps(
+        f"http://foo.com:8080"
     )
 
 
@@ -69,8 +71,10 @@ def test_provide_profiling_ingress(
     assert profiling_out.local_app_data["otlp_grpc_endpoint_url"] == json.dumps(
         f"{external_host}:{nginx_config.grpc_server_port}"
     )
-    assert profiling_out.local_app_data.get("otlp_http_endpoint_url") == json.dumps(
-        None
+    assert profiling_out.local_app_data.get(
+        "pyroscope_http_endpoint_url"
+    ) == json.dumps(
+        f"http://example.com/{state_out.model.name}-pyroscope-coordinator-k8s"
     )
 
 
@@ -78,17 +82,17 @@ def test_provide_profiling_ingress(
     "databag, expected",
     (
         ({}, []),
-        ({"otlp_http_endpoint_url": '"http://foo.com:1234"'}, []),
+        ({"pyroscope_http_endpoint_url": '"http://foo.com:1234"'}, []),
         (
             {"otlp_grpc_endpoint_url": '"foo.com:1234"'},
-            [_Endpoint(otlp_grpc="foo.com:1234", otlp_http=None)],
+            [_Endpoint(otlp_grpc="foo.com:1234", pyroscope_http=None)],
         ),
         (
             {
                 "otlp_grpc_endpoint_url": '"foo.com:1234"',
-                "otlp_http_endpoint_url": '"http://foo.com:1234"',
+                "pyroscope_http_endpoint_url": '"http://foo.com:1234"',
             },
-            [_Endpoint(otlp_grpc="foo.com:1234", otlp_http="http://foo.com:1234")],
+            [_Endpoint(otlp_grpc="foo.com:1234", pyroscope_http="http://foo.com:1234")],
         ),
     ),
 )

--- a/coordinator/tests/unit/test_profiling_interface.py
+++ b/coordinator/tests/unit/test_profiling_interface.py
@@ -38,10 +38,6 @@ def test_provide_profiling(
     assert profiling_out.local_app_data["otlp_grpc_endpoint_url"] == json.dumps(
         f"foo.com:{nginx_config.grpc_server_port}"
     )
-    assert profiling_out.local_app_data.get(
-        "pyroscope_http_endpoint_url"
-    ) == json.dumps("http://foo.com:8080")
-
 
 def test_provide_profiling_ingress(
     context,
@@ -69,28 +65,15 @@ def test_provide_profiling_ingress(
     assert profiling_out.local_app_data["otlp_grpc_endpoint_url"] == json.dumps(
         f"{external_host}:{nginx_config.grpc_server_port}"
     )
-    assert profiling_out.local_app_data.get(
-        "pyroscope_http_endpoint_url"
-    ) == json.dumps(
-        f"http://example.com/{state_out.model.name}-pyroscope-coordinator-k8s"
-    )
 
 
 @pytest.mark.parametrize(
     "databag, expected",
     (
         ({}, []),
-        ({"pyroscope_http_endpoint_url": '"http://foo.com:1234"'}, []),
         (
             {"otlp_grpc_endpoint_url": '"foo.com:1234"'},
-            [_Endpoint(otlp_grpc="foo.com:1234", pyroscope_http=None)],
-        ),
-        (
-            {
-                "otlp_grpc_endpoint_url": '"foo.com:1234"',
-                "pyroscope_http_endpoint_url": '"http://foo.com:1234"',
-            },
-            [_Endpoint(otlp_grpc="foo.com:1234", pyroscope_http="http://foo.com:1234")],
+            [_Endpoint(otlp_grpc="foo.com:1234")],
         ),
     ),
 )

--- a/coordinator/tests/unit/test_profiling_interface.py
+++ b/coordinator/tests/unit/test_profiling_interface.py
@@ -40,9 +40,7 @@ def test_provide_profiling(
     )
     assert profiling_out.local_app_data.get(
         "pyroscope_http_endpoint_url"
-    ) == json.dumps(
-        f"http://foo.com:8080"
-    )
+    ) == json.dumps("http://foo.com:8080")
 
 
 def test_provide_profiling_ingress(


### PR DESCRIPTION
As discussed, `otlp_http` is the name of a protocol and is not the protocol pyroscope is capable of ingesting over its http server.
This PR removes it [as per ADR](https://github.com/canonical/observability/pull/373/files), since there's nobody using it yet. We can add it back later if needed.

While not a backwards compatible change, it shouldn't break any existing requirers as they are only accessing the grpc endpoint.